### PR TITLE
Broken link

### DIFF
--- a/docs/configuration/configuration-start/index.html
+++ b/docs/configuration/configuration-start/index.html
@@ -347,7 +347,7 @@
 
 <p>On the other hand, when running a group of KrakenD instances using the <strong>KrakenD Cluster Manager</strong> (KCM) the configuration is automatically injected and updated by the manager to all running KrakenD nodes.</p>
 
-<p><a href="/docs/cluster/cluster-configuration/">Continue to Configure KrakenD Cluster</a></p>
+<p><a href="/docs/configuration/cluster/">Continue to Configure KrakenD Cluster</a></p>
 
 
             </div>


### PR DESCRIPTION
Broken link in http://www.krakend.io/docs/configuration/configuration-start/.

Link labelled "Continue to Configure KrakenD Cluster" causes 404