### PR TITLE
Delete an absolute reference

### DIFF
--- a/docs/commands/run/index.html
+++ b/docs/commands/run/index.html
@@ -1118,7 +1118,7 @@ can also specify the port (defaults to <code>8080</code>)</p>
 	</div>
 </div>
 
-<p>In development and testing phase <a href="http://localhost:1313/docs/logging-metrics-tracing/logging/#set-the-reporting-level">increase the verbosity of the logs</a></p>
+<p>In development and testing phase <a href="/docs/logging-metrics-tracing/logging/#set-the-reporting-level">increase the verbosity of the logs</a></p>
 
     </section>
 </div>


### PR DESCRIPTION
Just noticed while browsing the website.